### PR TITLE
Adding rolling to the bot

### DIFF
--- a/bot/commands/commands.go
+++ b/bot/commands/commands.go
@@ -101,3 +101,19 @@ func MessageSend(s *discordgo.Session, m *discordgo.MessageCreate, message strin
 		log.Printf("Sent message to channel %s: %s", m.ChannelID, message)
 	}
 }
+
+func MessagePrivateSend(s *discordgo.Session, m *discordgo.MessageCreate, message string) {
+	if len(message) > 2000 {
+		log.Printf("message exceeds Discord's 2000 character limit")
+	}
+	userChannel, err := s.UserChannelCreate(m.Author.ID)
+	if err != nil {
+		log.Printf("failed to open channel to user: %s", m.Author.DisplayName())
+	}
+	if _, err := s.ChannelMessageSend(userChannel.ID, message); err != nil {
+		log.Printf("failed to send message: %s", err.Error())
+	}
+	if config.Debug {
+		log.Printf("Sent message to channel %s: %s", m.ChannelID, message)
+	}
+}

--- a/bot/commands/dmroll.go
+++ b/bot/commands/dmroll.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func dmroll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
+	var (
+		args = c.Args()
+	)
+
+	if len(args) < 1 {
+		MessagePrivateSend(s, m, rollDuality())
+		return nil
+	}
+
+	var results []string
+
+	for _, roll := range args {
+
+		if roll == "duality" || roll == "duelity" {
+			results = append(results, rollDuality())
+			continue
+		}
+
+		isMultiDiceRoll, _ := regexp.MatchString("^[0-9]*d[0-9]+.*$", roll)
+
+		diceNum, err := strconv.ParseFloat(roll, 64)
+		if err != nil && !isMultiDiceRoll {
+			results = append(results, fmt.Sprintf("%s is not a valid roll. A roll is a number, duality, or dice abbreviation", roll))
+			continue
+		}
+		if isMultiDiceRoll {
+			results = append(results, multiDiceRoll(roll))
+		} else {
+			_, diceRollResultString := rollDice(diceNum)
+
+			if diceRollResultString == "1" {
+				results = append(results, fmt.Sprintf("your d%s result is %s :cry:\n", roll, diceRollResultString))
+				continue
+			}
+
+			results = append(results, fmt.Sprintf("your d%s result is %s\n", roll, diceRollResultString))
+		}
+	}
+
+	MessagePrivateSend(s, m, strings.Join(results, "\n"))
+	return nil
+
+}
+
+func init() {
+	RegisterCommand(NewCommand("DMRoll", "Replies with Roll!", dmroll))
+}

--- a/bot/commands/proll.go
+++ b/bot/commands/proll.go
@@ -23,7 +23,7 @@ func proll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 
 	for _, roll := range args {
 
-		if roll == "duality" || roll == "duelity" {
+		if strings.ToLower(roll) == "duality" || strings.ToLower(roll) == "duelity" {
 			results = append(results, rollDuality())
 			continue
 		}

--- a/bot/commands/proll.go
+++ b/bot/commands/proll.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func dmroll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
+func proll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 	var (
 		args = c.Args()
 	)
@@ -55,5 +55,5 @@ func dmroll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error 
 }
 
 func init() {
-	RegisterCommand(NewCommand("DMRoll", "Replies with Roll!", dmroll))
+	RegisterCommand(NewCommand("PRoll", "Privately replies with Roll!", proll))
 }

--- a/bot/commands/proll.go
+++ b/bot/commands/proll.go
@@ -36,7 +36,7 @@ func proll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 			continue
 		}
 		if isMultiDiceRoll {
-			results = append(results, multiDiceRoll(roll))
+			results = append(results, rollMultiDice(roll))
 		} else {
 			_, diceRollResultString := rollDice(diceNum)
 

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -25,7 +25,7 @@ func roll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 
 	for _, roll := range args {
 
-		if roll == "duality" || roll == "duelity" {
+		if strings.ToLower(roll) == "duality" || strings.ToLower(roll) == "duelity" {
 			results = append(results, rollDuality())
 			continue
 		}

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -111,7 +111,7 @@ func multiDiceRoll(diceDesignation string) string {
 	}
 	rollValue, err := strconv.ParseFloat(splitString[1], 64)
 	if err != nil {
-		return fmt.Sprintf("%s is not a valid roll. A roll is a number, duality, or dice abbreviation", diceDesignation)
+		return fmt.Sprintf("%s is not a valid roll. A roll is a number, duality, or dice abbreviation", diceDesignationString)
 	}
 	for i := 0; i < numRolls; i++ {
 		dicevalue, _ := rollDice(rollValue)

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func roll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
+	var (
+		args = c.Args()
+	)
+	args = nil
+
+	if len(args) < 1 {
+		MessageSend(s, m, rollDuality())
+		return nil
+	}
+
+	diceNum, err := strconv.ParseFloat(args[0], 64)
+	if err != nil {
+		MessageSend(s, m, "Need to roll a number or duality")
+		return nil
+	}
+	diceRollResult := int(math.Ceil(rand.Float64() * diceNum))
+	MessageSend(s, m, fmt.Sprintf("%o", diceRollResult))
+	return nil
+
+}
+
+func init() {
+	RegisterCommand(NewCommand("Roll", "Replies with Roll!", roll))
+}
+
+func rollDuality() string {
+
+	hope := int(math.Ceil(rand.Float64() * 12))
+	fear := int(math.Ceil(rand.Float64() * 12))
+	var dualityResult string
+
+	if hope > fear {
+		dualityResult = "You rolled with Hope :heart:"
+	} else if fear > hope {
+		dualityResult = "You rolled with Fear :dagger:"
+	} else {
+		dualityResult = "YOU CRIT!!!! :dagger: :heart:"
+	}
+
+	return fmt.Sprintf(">>> %s \nYour Hope roll was %o \nYour Fear roll was %o \nYour roll was %o\n %f", dualityResult, hope, fear, hope+fear, (rand.Float64() * 12))
+
+}
+
+func rollDice(num int) int {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return (r.Intn(num) + 1)
+}

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -38,7 +38,7 @@ func roll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 			continue
 		}
 		if isMultiDiceRoll {
-			results = append(results, multiDiceRoll(roll))
+			results = append(results, rollMultiDice(roll))
 		} else {
 			_, diceRollResultString := rollDice(diceNum)
 
@@ -88,7 +88,7 @@ func rollDice(diceSides float64) (float64, string) {
 	return diceRollResult, diceRollResultString
 }
 
-func multiDiceRoll(diceDesignation string) string {
+func rollMultiDice(diceDesignation string) string {
 	var positiveModifier float64 = 0
 	var negativeModifier float64 = 0
 	var diceTotal float64 = 0

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -111,7 +111,7 @@ func multiDiceRoll(diceDesignation string) string {
 	}
 	rollValue, err := strconv.ParseFloat(splitString[1], 64)
 	if err != nil {
-
+		return fmt.Sprintf("%s is not a valid roll. A roll is a number, duality, or dice abbreviation", diceDesignation)
 	}
 	for i := 0; i < numRolls; i++ {
 		dicevalue, _ := rollDice(rollValue)

--- a/bot/commands/roll.go
+++ b/bot/commands/roll.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"regexp"
 	"strconv"
-	"time"
+	"strings"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -14,20 +15,43 @@ func roll(c *Command, s *discordgo.Session, m *discordgo.MessageCreate) error {
 	var (
 		args = c.Args()
 	)
-	args = nil
 
 	if len(args) < 1 {
 		MessageSend(s, m, rollDuality())
 		return nil
 	}
 
-	diceNum, err := strconv.ParseFloat(args[0], 64)
-	if err != nil {
-		MessageSend(s, m, "Need to roll a number or duality")
-		return nil
+	var results []string
+
+	for _, roll := range args {
+
+		if roll == "duality" || roll == "duelity" {
+			results = append(results, rollDuality())
+			continue
+		}
+
+		isMultiDiceRoll, _ := regexp.MatchString("^[0-9]*d[0-9]+.*$", roll)
+
+		diceNum, err := strconv.ParseFloat(roll, 64)
+		if err != nil && !isMultiDiceRoll {
+			results = append(results, fmt.Sprintf("%s is not a valid roll. A roll is a number, duality, or dice abbreviation", roll))
+			continue
+		}
+		if isMultiDiceRoll {
+			results = append(results, multiDiceRoll(roll))
+		} else {
+			_, diceRollResultString := rollDice(diceNum)
+
+			if diceRollResultString == "1" {
+				results = append(results, fmt.Sprintf("your d%s result is %s :cry:\n", roll, diceRollResultString))
+				continue
+			}
+
+			results = append(results, fmt.Sprintf("your d%s result is %s\n", roll, diceRollResultString))
+		}
 	}
-	diceRollResult := int(math.Ceil(rand.Float64() * diceNum))
-	MessageSend(s, m, fmt.Sprintf("%o", diceRollResult))
+
+	MessageSend(s, m, strings.Join(results, "\n"))
 	return nil
 
 }
@@ -38,8 +62,12 @@ func init() {
 
 func rollDuality() string {
 
-	hope := int(math.Ceil(rand.Float64() * 12))
-	fear := int(math.Ceil(rand.Float64() * 12))
+	hope, hopeString := rollDice(12)
+	fear, fearString := rollDice(12)
+
+	result := hope + fear
+	resultString := strconv.FormatFloat(result, 'f', -1, 64)
+
 	var dualityResult string
 
 	if hope > fear {
@@ -47,14 +75,51 @@ func rollDuality() string {
 	} else if fear > hope {
 		dualityResult = "You rolled with Fear :dagger:"
 	} else {
-		dualityResult = "YOU CRIT!!!! :dagger: :heart:"
+		dualityResult = "# YOU CRIT!!!! :dagger: :heart:"
 	}
 
-	return fmt.Sprintf(">>> %s \nYour Hope roll was %o \nYour Fear roll was %o \nYour roll was %o\n %f", dualityResult, hope, fear, hope+fear, (rand.Float64() * 12))
+	return fmt.Sprintf("> %s \n> Your Hope roll was %s \n> Your Fear roll was %s \n> Your total was %s\n", dualityResult, hopeString, fearString, resultString)
 
 }
 
-func rollDice(num int) int {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return (r.Intn(num) + 1)
+func rollDice(diceSides float64) (float64, string) {
+	diceRollResult := math.Ceil(rand.Float64() * diceSides)
+	diceRollResultString := strconv.FormatFloat(diceRollResult, 'f', -1, 64)
+	return diceRollResult, diceRollResultString
+}
+
+func multiDiceRoll(diceDesignation string) string {
+	var positiveModifier float64 = 0
+	var negativeModifier float64 = 0
+	var diceTotal float64 = 0
+	var diceDesignationString = diceDesignation
+
+	if strings.Contains(diceDesignation, "+") {
+		modifierSplitStrings := strings.Split(diceDesignation, "+")
+		positiveModifier, _ = strconv.ParseFloat(modifierSplitStrings[1], 64)
+		diceDesignation = modifierSplitStrings[0]
+	} else if strings.Contains(diceDesignation, "-") {
+		modifierSplitStrings := strings.Split(diceDesignation, "-")
+		negativeModifier, _ = strconv.ParseFloat(modifierSplitStrings[1], 64)
+		diceDesignation = modifierSplitStrings[0]
+	}
+
+	splitString := strings.Split(diceDesignation, "d")
+	numRolls, err := strconv.Atoi(splitString[0])
+	if err != nil {
+		numRolls = 1
+	}
+	rollValue, err := strconv.ParseFloat(splitString[1], 64)
+	if err != nil {
+
+	}
+	for i := 0; i < numRolls; i++ {
+		dicevalue, _ := rollDice(rollValue)
+		diceTotal += dicevalue
+	}
+
+	diceTotal += (positiveModifier - negativeModifier)
+	diceTotalString := strconv.FormatFloat(diceTotal, 'f', -1, 64)
+
+	return fmt.Sprintf("your %s result is %s\n", diceDesignationString, diceTotalString)
 }

--- a/bot/handlers/on_message.go
+++ b/bot/handlers/on_message.go
@@ -84,9 +84,7 @@ func OnMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	cmd.SetGuild(guild)
 
 	// Inject any args into the command
-	if len(fullcmd) > 1 {
-		cmd.SetArgs(fullcmd[1:])
-	}
+	cmd.SetArgs(fullcmd[1:])
 
 	if cmd.Admin() && !guild.IsAdmin(m.Member) {
 		log.Printf("[%s] user @%s (%s) is not an admin, denying access to %s command", guild.Name, m.Author.DisplayName(), m.Author, cmd.Name)


### PR DESCRIPTION
# Roll

> no options will return a duality roll, e.g. `!roll` 

## Dice Formats

| option | result | example |
|-------|--------|------|
| plain number | result of a single roll of a dice with that many sides | !roll 8 |
| dice notation | the bot will total the number of dice rolled and add any modifiers | !roll 4d6+3 |
| multiple rolls | each roll result will be displayed separately | !roll 8 20 2d6-1 |
| duality rolls | will roll Daggerhearts Duality dice (this is the default behavior if no options are included) | !roll duality |

# DMRoll

Everything is the same as roll except the rolls will be whispered to the person who executed the command. e.g. `!dmroll`
